### PR TITLE
Disables the quest to make an augmentable Mage Epic

### DIFF
--- a/toxxulia/Ilisiv_Gantrau.pl
+++ b/toxxulia/Ilisiv_Gantrau.pl
@@ -4,16 +4,11 @@ sub EVENT_SAY {
     quest::say("You wield great power. The wind whispers to me. You seek to learn more about the augmentation stones found in ruins long forgotten. They hold great power. A mysterious power. I fear however that if you were to fuse one of these magical stones to your Orb of Mastery, it would be lost due to the transitory nature of the Orb. I believe after much research I have discovered a way for you to make use of these stones if you are [interested].");
   }
   elsif($text=~/interested/i) {
-    quest::say("Hand me your Orb of Mastery. I must infuse the power of the elements into a new orb.");
+    quest::say("It looks like your Orb of Mastery is already able to make use of augmentation stones. I cannot help you further.");
   }
 }
 
 sub EVENT_ITEM {
-  if(plugin::check_handin(\%itemcount, 28034 => 1)) { #Orb of Mastery (summoned)
-    quest::emote("begins to chant an incantation. The power within the orb begins to grow. A bright flash nearly knocks you to the ground as the power within the Orb begins to flow around you and Ilisiv. Ilisiv kneels down and etches a triangle in the dirt with her fingers. The triangle begins to glow and the power within the orb erupts in a brilliant display of color and immediately infuses the triangle with its power. Ilisiv makes a final gesture over the triangle and a brief swirl of luminescent light encompasses her. A new orb appears on the ground in the center of the triangle. Ilisiv holds her hand over the triangle and after a moment, all is calm again. The glowing light of the triangle fades.");
-    quest::say("I do believe this was a success. The power of summoning and elements has been infused into a new orb. Take this new Orb of Mastery. You may now safely use the power of the augmentation stones with your new orb.");
-    quest::summonitem(55273); #Ornate Orb of Mastery
-  }
   plugin::return_items(\%itemcount);
 }
 #Scripted By: Fatty Beerbelly


### PR DESCRIPTION
This disables the augmentable Mage Epic quest which results in this item: https://www.pyrelight.net/allaclone/?a=item&id=55273

It's not actually needed on this server.