### PR TITLE
Fixes quests overriding default spawn timers in ssratemple

### DIFF
--- a/ssratemple/#EmpCycle.pl
+++ b/ssratemple/#EmpCycle.pl
@@ -1,7 +1,7 @@
 #BEGIN File: ssratemple\#EmpCycle.pl
 
-my $BloodCoolDownTime = int(rand(60)) + 180; #Waiting time to reattempt Emp after failure (Current setting: 3-4 hours)
-my $EmpRepopTime = int(rand(2880)) + 4320; #Respawn time for Emp after success (Current setting: 3-5 days)
+my $BloodCoolDownTime = 90; #Waiting time to reattempt Emp after failure (Current setting: 90 minutes)
+my $EmpRepopTime =90; #Respawn time for Emp after success (Current setting: 90 minutes)
 my $EmpPrepTime = 150; #Seconds before Emp becomes targetable after killing Blood/Golem (Current setting: 2min 30sec)
 my $EmpPrep;
 

--- a/ssratemple/#cursed_controller.pl
+++ b/ssratemple/#cursed_controller.pl
@@ -1,6 +1,5 @@
 my $check;
-my $variance = int(rand(600));
-my $spawntime = 4320 + $variance;
+my $spawntime = 90;
 
 sub EVENT_SPAWN {
   quest::settimer("cursed",60);


### PR DESCRIPTION
Right now these quests are causing the spawn timers to fall back to their PEQ defaults (~days) rather than the timers that have been set for them in the Pyrelight DB.